### PR TITLE
Add support for other Albertsons stores, like Jewel

### DIFF
--- a/safeway_coupons/accounts.py
+++ b/safeway_coupons/accounts.py
@@ -7,3 +7,4 @@ class Account:
     password: str = field(repr=False)
     mail_to: str
     mail_from: str
+    store_url: str

--- a/safeway_coupons/app.py
+++ b/safeway_coupons/app.py
@@ -7,7 +7,7 @@ from .safeway import SafewayCoupons
 
 
 def _parse_args() -> argparse.Namespace:
-    description = 'Automatic coupon clipper for "Jewel Just4U" coupons'
+    description = 'Automatic coupon clipper for "Just4U" coupons'
     arg_parser = argparse.ArgumentParser(description=description)
     arg_parser.add_argument(
         "-c",

--- a/safeway_coupons/app.py
+++ b/safeway_coupons/app.py
@@ -7,7 +7,7 @@ from .safeway import SafewayCoupons
 
 
 def _parse_args() -> argparse.Namespace:
-    description = 'Automatic coupon clipper for "Safeway for U" coupons'
+    description = 'Automatic coupon clipper for "Jewel Just4U" coupons'
     arg_parser = argparse.ArgumentParser(description=description)
     arg_parser.add_argument(
         "-c",

--- a/safeway_coupons/client.py
+++ b/safeway_coupons/client.py
@@ -26,7 +26,7 @@ class SafewayClient(BaseSession):
     def get_offers(self) -> List[Offer]:
         try:
             response = self.requests.get(
-                "https://www.safeway.com/abs/pub/xapi"
+                "https://www.jewelosco.com/abs/pub/xapi"
                 "/offers/companiongalleryoffer"
                 f"?storeId={self.session.store_id}"
                 f"&rand={random.randrange(100000,999999)}",
@@ -41,7 +41,7 @@ class SafewayClient(BaseSession):
         response: Optional[requests.Response] = None
         try:
             response = self.requests.post(
-                "https://www.safeway.com/abs/pub/web/j4u/api/offers/clip"
+                "https://www.jewelosco.com/abs/pub/web/j4u/api/offers/clip"
                 f"?storeId={self.session.store_id}",
                 data=json.dumps(request.to_dict(encode_json=True)),
                 headers={"Content-Type": "application/json"},

--- a/safeway_coupons/client.py
+++ b/safeway_coupons/client.py
@@ -14,6 +14,7 @@ from .session import BaseSession, LoginSession
 class SafewayClient(BaseSession):
     def __init__(self, account: Account) -> None:
         self.session = LoginSession(account)
+        self.store_url = account.store_url
         self.requests.headers.update(
             {
                 "Authorization": f"Bearer {self.session.access_token}",
@@ -26,7 +27,7 @@ class SafewayClient(BaseSession):
     def get_offers(self) -> List[Offer]:
         try:
             response = self.requests.get(
-                "https://www.jewelosco.com/abs/pub/xapi"
+                f"https://{self.store_url}/abs/pub/xapi"
                 "/offers/companiongalleryoffer"
                 f"?storeId={self.session.store_id}"
                 f"&rand={random.randrange(100000,999999)}",
@@ -41,7 +42,7 @@ class SafewayClient(BaseSession):
         response: Optional[requests.Response] = None
         try:
             response = self.requests.post(
-                "https://www.jewelosco.com/abs/pub/web/j4u/api/offers/clip"
+                f"https://{self.store_url}/abs/pub/web/j4u/api/offers/clip"
                 f"?storeId={self.session.store_id}",
                 data=json.dumps(request.to_dict(encode_json=True)),
                 headers={"Content-Type": "application/json"},

--- a/safeway_coupons/config.py
+++ b/safeway_coupons/config.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 from .accounts import Account
 
+DEFAULT_STORE_URL = "www.safeway.com"
 
 class Config:
     @classmethod
@@ -24,12 +25,14 @@ class Config:
         password = os.environ.get("SAFEWAY_ACCOUNT_PASSWORD")
         mail_to = os.environ.get("SAFEWAY_ACCOUNT_MAIL_TO")
         mail_from = os.environ.get("SAFEWAY_ACCOUNT_MAIL_TO")
+        store_url = os.environ.get("STORE_URL")
         if username and password:
             return Account(
                 username=username,
                 password=password,
                 mail_to=mail_to or username,
                 mail_from=mail_from or username,
+                store_url=store_url or DEFAULT_STORE_URL
             )
         return None
 
@@ -50,6 +53,11 @@ class Config:
                 if config.has_option(section, "notify")
                 else None
             )
+            store_url = (
+                config.get(section, "store_url")
+                if config.has_option(section, "store_url")
+                else None
+            )
             username = str(section)
             accounts.append(
                 Account(
@@ -57,6 +65,7 @@ class Config:
                     password=config.get(section, "password"),
                     mail_to=mail_to or username,
                     mail_from=mail_from or username,
+                    store_url=store_url or DEFAULT_STORE_URL
                 )
             )
         return accounts

--- a/safeway_coupons/safeway.py
+++ b/safeway_coupons/safeway.py
@@ -28,7 +28,7 @@ class SafewayCoupons:
         self.max_clip_errors = max_clip_errors
 
     def clip_for_account(self, account: Account) -> None:
-        print(f"Clipping coupons for Safeway account {account.username}")
+        print(f"Clipping coupons for Safeway account {account.username} using url {account.store_url}")
         swy = SafewayClient(account)
         clipped_offers: List[Offer] = []
         clip_errors: List[ClipError] = []

--- a/safeway_coupons/session.py
+++ b/safeway_coupons/session.py
@@ -14,9 +14,6 @@ AUTHORIZE_URL = (
 )
 
 OAUTH_CLIENT_ID = "0oap6ku01XJqIRdl42p6"
-OAUTH_REDIRECT_URI = (
-    "https://www.jewelosco.com/bin/safeway/unified/sso/authorize"
-)
 
 
 class BaseSession:
@@ -62,7 +59,7 @@ class LoginSession(BaseSession):
         nonce = make_nonce()
         params = {
             "client_id": OAUTH_CLIENT_ID,
-            "redirect_uri": OAUTH_REDIRECT_URI,
+            "redirect_uri": (f"https://{account.store_url}/bin/safeway/unified/sso/authorize"),
             "response_type": "code",
             "response_mode": "query",
             "state": state_token,

--- a/safeway_coupons/session.py
+++ b/safeway_coupons/session.py
@@ -15,7 +15,7 @@ AUTHORIZE_URL = (
 
 OAUTH_CLIENT_ID = "0oap6ku01XJqIRdl42p6"
 OAUTH_REDIRECT_URI = (
-    "https://www.safeway.com/bin/safeway/unified/sso/authorize"
+    "https://www.jewelosco.com/bin/safeway/unified/sso/authorize"
 )
 
 


### PR DESCRIPTION
See https://github.com/smkent/safeway-coupons/issues/72 for context.

Adds support for an arbitrary `store_url` config parameter that defaults to `www.safeway.com`. 

I've tested the changes locally (aka it works on my machine) using the alternate `store_url: www.jewelosco.com`

With these changes I can successfully clip all Just4U coupons for Jewel-Osco, my local grocery store.