### PR TITLE
brand parameter proof of concept

### DIFF
--- a/safeway_coupons/app.py
+++ b/safeway_coupons/app.py
@@ -4,11 +4,21 @@ from http.client import HTTPConnection
 
 from .config import Config
 from .safeway import SafewayCoupons
+from .brands import brands
 
 
 def _parse_args() -> argparse.Namespace:
     description = 'Automatic coupon clipper for "Safeway for U" coupons'
     arg_parser = argparse.ArgumentParser(description=description)
+    arg_parser.add_argument(
+        "-b",
+        "--brand",
+        dest="brand",
+        action="store",
+        help=(
+            "Brand to use for clipping coupons (defaults to Safeway)"
+        ),
+    )
     arg_parser.add_argument(
         "-c",
         "--accounts-config",
@@ -76,12 +86,15 @@ def main() -> None:
         sys.exit(1)
     if args.debug_level >= 2:
         HTTPConnection.debuglevel = 1
+    if args.brand:
+        brand_url = brands.get(args.brand, "safeway")
     sc = SafewayCoupons(
         send_email=args.send_email,
         debug_level=args.debug_level,
         sleep_level=args.sleep_level,
         dry_run=args.dry_run,
         max_clip_count=args.max_clip_count,
+        brand_url=brand_url
     )
     try:
         for account in accounts:

--- a/safeway_coupons/brands.py
+++ b/safeway_coupons/brands.py
@@ -1,0 +1,5 @@
+
+brands = {
+    "safeway" : "www.safeway.com",
+    "jewel-osco" : "www.jewelosco.com"
+}

--- a/safeway_coupons/client.py
+++ b/safeway_coupons/client.py
@@ -12,8 +12,9 @@ from .session import BaseSession, LoginSession
 
 
 class SafewayClient(BaseSession):
-    def __init__(self, account: Account) -> None:
-        self.session = LoginSession(account)
+    def __init__(self, account: Account, brand_url: str) -> None:
+        self.session = LoginSession(account, brand_url)
+        self.brand_url = brand_url
         self.requests.headers.update(
             {
                 "Authorization": f"Bearer {self.session.access_token}",
@@ -26,7 +27,7 @@ class SafewayClient(BaseSession):
     def get_offers(self) -> List[Offer]:
         try:
             response = self.requests.get(
-                "https://www.safeway.com/abs/pub/xapi"
+                f"https://{self.brand_url}/abs/pub/xapi"
                 "/offers/companiongalleryoffer"
                 f"?storeId={self.session.store_id}"
                 f"&rand={random.randrange(100000,999999)}",
@@ -41,7 +42,7 @@ class SafewayClient(BaseSession):
         response: Optional[requests.Response] = None
         try:
             response = self.requests.post(
-                "https://www.safeway.com/abs/pub/web/j4u/api/offers/clip"
+                f"https://{self.brand_url}/abs/pub/web/j4u/api/offers/clip"
                 f"?storeId={self.session.store_id}",
                 data=json.dumps(request.to_dict(encode_json=True)),
                 headers={"Content-Type": "application/json"},

--- a/safeway_coupons/safeway.py
+++ b/safeway_coupons/safeway.py
@@ -19,6 +19,7 @@ class SafewayCoupons:
         dry_run: bool = False,
         max_clip_count: int = 0,
         max_clip_errors: int = CLIP_ERROR_MAX,
+        brand_url: str = None
     ) -> None:
         self.send_email = send_email
         self.debug_level = debug_level
@@ -26,10 +27,11 @@ class SafewayCoupons:
         self.dry_run = dry_run
         self.max_clip_count = max_clip_count
         self.max_clip_errors = max_clip_errors
+        self.brand_url = brand_url
 
     def clip_for_account(self, account: Account) -> None:
         print(f"Clipping coupons for Safeway account {account.username}")
-        swy = SafewayClient(account)
+        swy = SafewayClient(account, self.brand_url)
         clipped_offers: List[Offer] = []
         clip_errors: List[ClipError] = []
         try:

--- a/safeway_coupons/session.py
+++ b/safeway_coupons/session.py
@@ -14,9 +14,6 @@ AUTHORIZE_URL = (
 )
 
 OAUTH_CLIENT_ID = "0oap6ku01XJqIRdl42p6"
-OAUTH_REDIRECT_URI = (
-    "https://www.safeway.com/bin/safeway/unified/sso/authorize"
-)
 
 
 class BaseSession:
@@ -38,9 +35,10 @@ class BaseSession:
 
 
 class LoginSession(BaseSession):
-    def __init__(self, account: Account) -> None:
+    def __init__(self, account: Account, brand_url: str) -> None:
         self.access_token: Optional[str] = None
         self.store_id: Optional[str] = None
+        self.brand_url: Optional[str] = brand_url
         try:
             self._login(account)
         except Exception as e:
@@ -62,7 +60,7 @@ class LoginSession(BaseSession):
         nonce = make_nonce()
         params = {
             "client_id": OAUTH_CLIENT_ID,
-            "redirect_uri": OAUTH_REDIRECT_URI,
+            "redirect_uri": (f"https://{self.brand_url}/bin/safeway/unified/sso/authorize"),
             "response_type": "code",
             "response_mode": "query",
             "state": state_token,


### PR DESCRIPTION
While I like the user-friendliness of selecting the brand on the command line, threading the `brand`/`brand_url` parameter through various objects is tedious. If the brand parameter were instead part of the account configuration this would be cleaner as the `account` object is already passed through the various required classes as a context providing object.